### PR TITLE
Fixing unused import, dotenv, filedata private fields

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -476,10 +476,6 @@ impl GemSession {
 
 mod tests {
 
-    use crate::types::HarmBlockThreshold;
-
-    use super::*;
-
     #[tokio::test]
     async fn test_gem_session_send_context() {
         dotenv().expect("Failed to load Gemini API key");

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, path::Path};
 
 use base64::{engine::general_purpose, Engine as _};
 use dotenv::dotenv;
-use log::log;
 use reqwest::header;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -158,8 +157,8 @@ impl Blob {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileData {
-    mime_type: String,
-    file_uri: String, // File URI
+    pub mime_type: String,
+    pub file_uri: String, // File URI
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -448,8 +447,8 @@ pub struct FileManager {
 
 impl FileManager {
     pub fn new() -> Self {
-        dotenv().expect("Failed to load Gemini API key");
-        let api_key = std::env::var("GEMINI_API_KEY").unwrap();
+        dotenv().ok();
+        let api_key = std::env::var("GEMINI_API_KEY").expect("Failed to load Gemini API key");
 
         Self {
             files: Mutex::new(HashMap::new()),
@@ -974,8 +973,6 @@ impl Context {
 }
 
 mod tests {
-
-    use super::*;
 
     #[test]
     fn test_deserialize_generate_content_response() {


### PR DESCRIPTION
The PR contains the following fixes:
1. Removing unused imports
2. Previously the following was used:
```rust
dotenv().expect("...")
```
This causes an error if there is no `.env` file which is a very possible case when deploying things as the env variables are directly put into the env of the execution. This is now changed to
```rust
dotenv().ok()
```
which doesnot cause this error
3. Making `pub` to the `FileData` struct.  Previously the `FileData` struct had private members.  Thus if suppose `add_file()` is getting called it will return the `FileData` which is totally unaccessible (untill you `deseralize` and `serialize` it). This PR makes the struct members of `FileData` `pub` to make it usable