### PR TITLE
Add support for sending multiple files and blobs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -542,6 +542,17 @@ impl GemSession {
         Ok(Box::new(self.send_context_stream(settings).await?))
     }
 
+    /// Sends multiple files to the Gemini API and returns a stream of responses.
+    pub async fn send_files_stream(
+        &mut self,
+        files_data: &[FileData],
+        role: Role,
+        settings: &Settings,
+    ) -> StreamResponseResult {
+        self.context.push_files(role, files_data);
+        Ok(Box::new(self.send_context_stream(settings).await?))
+    }
+
     /// Sends a blob to the Gemini API and returns a stream of responses.
     pub async fn send_blob_stream(
         &mut self,
@@ -550,6 +561,17 @@ impl GemSession {
         settings: &Settings,
     ) -> StreamResponseResult {
         self.context.push_blob(role, blob);
+        Ok(Box::new(self.send_context_stream(settings).await?))
+    }
+
+    /// Sends multiple blobs to the Gemini API and returns a stream of responses.
+    pub async fn send_blobs_stream(
+        &mut self,
+        blobs: &[Blob],
+        role: Role,
+        settings: &Settings,
+    ) -> StreamResponseResult {
+        self.context.push_blobs(role, blobs);
         Ok(Box::new(self.send_context_stream(settings).await?))
     }
 
@@ -566,6 +588,19 @@ impl GemSession {
         Ok(Box::new(self.send_context_stream(settings).await?))
     }
 
+    /// Sends a message with multiple attached files to the Gemini API and returns a stream of responses.
+    pub async fn send_message_with_files_stream(
+        &mut self,
+        message: &str,
+        files_data: &[FileData],
+        role: Role,
+        settings: &Settings,
+    ) -> StreamResponseResult {
+        self.context
+            .push_message_with_files(role, message, files_data);
+        Ok(Box::new(self.send_context_stream(settings).await?))
+    }
+
     /// Sends a message with an attached blob to the Gemini API and returns a stream of responses.
     pub async fn send_message_with_blob_stream(
         &mut self,
@@ -575,6 +610,18 @@ impl GemSession {
         settings: &Settings,
     ) -> StreamResponseResult {
         self.context.push_message_with_blob(role, message, blob);
+        Ok(Box::new(self.send_context_stream(settings).await?))
+    }
+
+    /// Sends a message with multiple attached blobs to the Gemini API and returns a stream of responses.
+    pub async fn send_message_with_blobs_stream(
+        &mut self,
+        message: &str,
+        blobs: &[Blob],
+        role: Role,
+        settings: &Settings,
+    ) -> StreamResponseResult {
+        self.context.push_message_with_blobs(role, message, blobs);
         Ok(Box::new(self.send_context_stream(settings).await?))
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -399,6 +399,29 @@ impl GemSession {
         Ok(response)
     }
 
+    /// Sends multiple blobs to the Gemini API and returns the response.
+    pub async fn send_blobs(
+        &mut self,
+        blobs: &[Blob],
+        role: Role,
+        settings: &Settings,
+    ) -> ResponseResult {
+        self.context.push_blobs(role, blobs);
+        let response = self.send_context(settings).await?;
+        if let Some(candidate) = response.get_candidates().first() {
+            if let Some(content) = candidate.get_content() {
+                self.context.push_message(
+                    Role::Model,
+                    match content.get_text() {
+                        Some(text) => text.clone(),
+                        None => return Err(GemError::EmptyApiResponse),
+                    },
+                );
+            }
+        }
+        Ok(response)
+    }
+
     /// Sends a message with an attached file to the Gemini API and returns the response.
     pub async fn send_message_with_file(
         &mut self,
@@ -458,6 +481,30 @@ impl GemSession {
         settings: &Settings,
     ) -> ResponseResult {
         self.context.push_message_with_blob(role, message, blob);
+        let response = self.send_context(settings).await?;
+        if let Some(candidate) = response.get_candidates().first() {
+            if let Some(content) = candidate.get_content() {
+                self.context.push_message(
+                    Role::Model,
+                    match content.get_text() {
+                        Some(text) => text.clone(),
+                        None => return Err(GemError::EmptyApiResponse),
+                    },
+                );
+            }
+        }
+        Ok(response)
+    }
+
+    /// Sends a message with multiple attached blobs to the Gemini API and returns the response.
+    pub async fn send_message_with_blobs(
+        &mut self,
+        message: &str,
+        blobs: &[Blob],
+        role: Role,
+        settings: &Settings,
+    ) -> ResponseResult {
+        self.context.push_message_with_blobs(role, message, blobs);
         let response = self.send_context(settings).await?;
         if let Some(candidate) = response.get_candidates().first() {
             if let Some(content) = candidate.get_content() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -352,6 +352,30 @@ impl GemSession {
         Ok(response)
     }
 
+    /// Sends multiple files to the Gemini API and returns the response.
+    pub async fn send_files(
+        &mut self,
+        files_data: &[FileData],
+        role: Role,
+        settings: &Settings,
+    ) -> ResponseResult {
+        self.context.push_files(role, files_data);
+
+        let response = self.send_context(settings).await?;
+        if let Some(candidate) = response.get_candidates().first() {
+            if let Some(content) = candidate.get_content() {
+                self.context.push_message(
+                    Role::Model,
+                    match content.get_text() {
+                        Some(text) => text.clone(),
+                        None => return Err(GemError::EmptyApiResponse),
+                    },
+                );
+            }
+        }
+        Ok(response)
+    }
+
     /// Sends a blob to the Gemini API and returns the response.
     pub async fn send_blob(
         &mut self,
@@ -385,6 +409,31 @@ impl GemSession {
     ) -> ResponseResult {
         self.context
             .push_message_with_file(role, message, file_data);
+        let response = self.send_context(settings).await?;
+        if let Some(candidate) = response.get_candidates().first() {
+            if let Some(content) = candidate.get_content() {
+                self.context.push_message(
+                    Role::Model,
+                    match content.get_text() {
+                        Some(text) => text.clone(),
+                        None => return Err(GemError::EmptyApiResponse),
+                    },
+                );
+            }
+        }
+        Ok(response)
+    }
+
+    /// Sends a message with multiple attached files to the Gemini API and returns the response.
+    pub async fn send_message_with_files(
+        &mut self,
+        message: &str,
+        files_data: &[FileData],
+        role: Role,
+        settings: &Settings,
+    ) -> ResponseResult {
+        self.context
+            .push_message_with_files(role, message, files_data);
         let response = self.send_context(settings).await?;
         if let Some(candidate) = response.get_candidates().first() {
             if let Some(content) = candidate.get_content() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -986,6 +986,15 @@ impl Context {
         });
     }
 
+    pub fn push_blobs(&mut self, role: Role, blobs: &[Blob]) {
+        self.contents.push(Content {
+            role: Some(role),
+            parts: blobs.iter().cloned().map(|blob| Part {
+                data: PartData::InlineData { inline_data: blob },
+            }).collect(),
+        });
+    }
+
     pub fn push_message_with_file(&mut self, role: Role, content: &str, file_data: FileData) {
         self.contents.push(Content {
             role: Some(role),
@@ -1030,6 +1039,21 @@ impl Context {
                     data: PartData::InlineData { inline_data: blob },
                 },
             ],
+        });
+    }
+
+    pub fn push_message_with_blobs(&mut self, role: Role, content: &str, blobs: &[Blob]) {
+        self.contents.push(Content {
+            role: Some(role),
+            parts: std::iter::once(Part {
+                data: PartData::Text {
+                    text: content.to_string(),
+                },
+            })
+            .chain(blobs.iter().cloned().map(|blob| Part {
+                data: PartData::InlineData { inline_data: blob },
+            }))
+            .collect(),
         });
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -968,6 +968,15 @@ impl Context {
         });
     }
 
+    pub fn push_files(&mut self, role: Role, files_data: &[FileData]) {
+        self.contents.push(Content {
+            role: Some(role),
+            parts: files_data.iter().cloned().map(|file_data| Part {
+                data: PartData::FileData { file_data },
+            }).collect(),
+        });
+    }
+
     pub fn push_blob(&mut self, role: Role, blob: Blob) {
         self.contents.push(Content {
             role: Some(role),
@@ -990,6 +999,21 @@ impl Context {
                     data: PartData::FileData { file_data },
                 },
             ],
+        });
+    }
+
+    pub fn push_message_with_files(&mut self, role: Role, content: &str, files_data: &[FileData]) {
+        self.contents.push(Content {
+            role: Some(role),
+            parts: std::iter::once(Part {
+                data: PartData::Text {
+                    text: content.to_string(),
+                },
+            })
+            .chain(files_data.iter().cloned().map(|file_data| Part {
+                data: PartData::FileData { file_data },
+            }))
+            .collect(),
         });
     }
 


### PR DESCRIPTION
This PR adds support for sending more than one file in one message. I needed this functionality in my project using Gem-rs, but the current API only handles one file per message. This change fills that gap without changing any existing behavior.

#### New functions for multi-file messaging:

- `send_files`
- `send_blobs`
- `send_message_with_files`
- `send_message_with_blobs`
- `send_files_stream`
- `send_blobs_stream`
- `send_message_with_files_stream`
- `send_message_with_blobs_stream`

All of them accept a collection of files/blobs and send them as a single message.

#### Example

```rust
let blobs = vec![
    Blob::new(
        "image/png",
        include_bytes!("/home/anon/Pictures/CoolAnimePics/DPqT0.png"),
    ),
    Blob::new(
        "image/jpeg",
        include_bytes!("/home/anon/Pictures/CoolAnimePics/stein.jpg"),
    ),
];

let response = session
    .send_message_with_blobs(
        "Analyze the given images and describe them in UwU style.",
        &blobs,
        Role::User,
        &settings,
    )
    .await?;
```